### PR TITLE
Retrieve image shape for reshaping flattened image

### DIFF
--- a/shapelink/shapein_simulator.py
+++ b/shapelink/shapein_simulator.py
@@ -101,6 +101,7 @@ class ShapeInSimulator:
                    scalar_values: np.array,
                    # vector of vector of short
                    vector_values: List[np.array],
+                   im_shape: np.array,
                    image_values: List[np.array]) -> bool:
         """Send a single event to the other process"""
 
@@ -116,10 +117,14 @@ class ShapeInSimulator:
         assert np.issubdtype(scalar_values.dtype, np.floating)
 
         qstream_write_array(msg_stream, scalar_values)
+
         msg_stream.writeUInt32(self.vector_len)
         for e in vector_values:
             assert e.dtype == np.int16, "fluorescence data is int16"
             qstream_write_array(msg_stream, e)
+
+        # im_shape
+        qstream_write_array(msg_stream, im_shape)
 
         msg_stream.writeUInt32(self.image_len)
         for e in image_values:
@@ -206,7 +211,10 @@ def start_simulator(path, features=None, verbose=1):
         for event_index in range(len(ds)):
             scalars = list()
             vectors = list()
+            im_shape = np.array(ds["image"][event_index].shape,
+                                dtype=np.uint8)
             images = list()
+
             for feat in sc_features:
                 scalars.append(ds[feat][event_index])
             for feat in tr_features:
@@ -219,6 +227,7 @@ def start_simulator(path, features=None, verbose=1):
             s.send_event(event_index,
                          np.array(scalars, dtype=np.float64),
                          vectors,
+                         im_shape,
                          images)
             c += 1
 

--- a/shapelink/shapein_simulator.py
+++ b/shapelink/shapein_simulator.py
@@ -197,13 +197,13 @@ def start_simulator(path, features=None, verbose=1):
         else:
             tr_features = []
 
-        im_shape = np.array(ds["image"][0].shape, dtype=np.uint8)
+        image_shape = np.array(ds["image"][0].shape, dtype=np.uint16)
 
         s.register_parameters(
             scalar_hdf5_names=sc_features,
             vector_hdf5_names=tr_features,
             image_hdf5_names=im_features,
-            image_shape=im_shape,
+            image_shape=image_shape,
             settings_names=[],
             settings_values=[],
         )

--- a/shapelink/shapelink_plugin.py
+++ b/shapelink/shapelink_plugin.py
@@ -41,7 +41,7 @@ class ShapeLinkPlugin(abc.ABC):
         self.scalar_len = 0
         self.vector_len = 0
         self.image_len = 0
-        self.image_shape = np.array([])
+        self.image_shape = None
         self.image_shape_len = 2
         self.registered_data_format = EventData()
         self.registered = False
@@ -78,7 +78,7 @@ class ShapeLinkPlugin(abc.ABC):
             self.registered_data_format.scalars = rcv_stream.readQStringList()
             self.registered_data_format.traces = rcv_stream.readQStringList()
             self.registered_data_format.images = rcv_stream.readQStringList()
-            self.image_shape = qstream_read_array(rcv_stream, np.uint8)
+            self.image_shape = qstream_read_array(rcv_stream, np.uint16)
             assert self.image_shape_len == len(self.image_shape)
 
             send_stream.writeInt64(msg_def.MSG_ID_REGISTER_ACK)
@@ -115,8 +115,8 @@ class ShapeLinkPlugin(abc.ABC):
             # read images piece by piece
             for i in range(n_images):
                 e.images.append(qstream_read_array(rcv_stream, np.uint8))
-                for ii, im in enumerate(e.images):
-                    e.images[ii] = np.reshape(e.images[ii], self.image_shape)
+                for j, im in enumerate(e.images):
+                    e.images[j] = np.reshape(e.images[j], self.image_shape)
 
             # pass event object to user-defined method
             ret = self.handle_event(e)


### PR DESCRIPTION
The image shape is sent through the EventData, and is used to reshape the flattened image array during handle messages (register phase).
 