### PR TITLE
Remove deprecated mentions of setup.py test

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Running tests
 
 ::
 
-    python setup.py test
+    pytest tests
 
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,5 @@
-[aliases]
-test=pytest
-
 [bdist_wheel]
 universal = 1
 
 [metadata]
 license_file = LICENSE
-

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
     },
     setup_requires=['pytest-runner'],
     python_requires=">=3.6",
-    tests_require=["pytest"],
     include_package_data=True,
     keywords=["fcs", "flow cytometry", "flow cytometry standard"],
     classifiers=['Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
             "shape-link = shapelink.cli:main",
         ],
     },
-    setup_requires=['pytest-runner'],
     python_requires=">=3.6",
     include_package_data=True,
     keywords=["fcs", "flow cytometry", "flow cytometry standard"],


### PR DESCRIPTION
This PR will update testing for shapelink. Certain setup.py tools are now out of date and described in #9.

 - [x] clean setup.cfg
 - [x] clean setup.py
 - [ ] verify that tests and plugins work > **waiting on PR #8 to be merged** which will solve the CodeCov issue

Closes #9 