### PR TITLE
Reshape image features correctly

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 0.2.1
+ - test: added image and scalar choose feature tests, verbose tests
+ - fix: contour shape is now correctly reshaped by the plugin. The image
+   features are now not repeatedly reshaped.
  - docs: added how-to guide for local and remote benchmark tests
  - test: added first benchmark test
  - test: allow Plugin to bind to random port, fixes ZMQ Address Error

--- a/shapelink/shapelink_plugin.py
+++ b/shapelink/shapelink_plugin.py
@@ -172,11 +172,17 @@ class ShapeLinkPlugin(abc.ABC):
             for im_name in self.reg_features.images:
                 if im_name == "mask":
                     e.images.append(qstream_read_array(rcv_stream, np.bool_))
-                else:
+                    e.images[-1] = np.reshape(e.images[-1], self.image_shape)
+                elif im_name == "contour":
                     e.images.append(qstream_read_array(rcv_stream, np.uint8))
-                for i, im in enumerate(e.images):
-                    e.images[i] = np.reshape(e.images[i], self.image_shape)
-
+                    e.images[-1] = np.reshape(e.images[-1],
+                                             (len(e.images[-1])//2, 2))
+                elif im_name == "image":
+                    e.images.append(qstream_read_array(rcv_stream, np.uint8))
+                    e.images[-1] = np.reshape(e.images[-1], self.image_shape)
+                else:
+                    raise ValueError(
+                        "Image feature '{}' not recognised".format(im_name))
         return e
 
     def run_EOT_message(self, send_stream):

--- a/shapelink/shapelink_plugin.py
+++ b/shapelink/shapelink_plugin.py
@@ -171,15 +171,15 @@ class ShapeLinkPlugin(abc.ABC):
             # read images piece by piece, checking for binary mask
             for im_name in self.reg_features.images:
                 if im_name == "mask":
-                    e.images.append(qstream_read_array(rcv_stream, np.bool_))
-                    e.images[-1] = np.reshape(e.images[-1], self.image_shape)
+                    mask_data = qstream_read_array(rcv_stream, np.bool_)
+                    e.images.append(mask_data.reshape(self.image_shape))
                 elif im_name == "contour":
-                    e.images.append(qstream_read_array(rcv_stream, np.uint8))
-                    e.images[-1] = np.reshape(
-                        e.images[-1], (len(e.images[-1])//2, 2))
+                    contour_data = qstream_read_array(rcv_stream, np.uint8)
+                    e.images.append(
+                        contour_data.reshape(len(contour_data)//2, 2))
                 elif im_name == "image":
-                    e.images.append(qstream_read_array(rcv_stream, np.uint8))
-                    e.images[-1] = np.reshape(e.images[-1], self.image_shape)
+                    image_data = qstream_read_array(rcv_stream, np.uint8)
+                    e.images.append(image_data.reshape(self.image_shape))
                 else:
                     raise ValueError(
                         "Image feature '{}' not recognised".format(im_name))

--- a/shapelink/shapelink_plugin.py
+++ b/shapelink/shapelink_plugin.py
@@ -175,8 +175,8 @@ class ShapeLinkPlugin(abc.ABC):
                     e.images[-1] = np.reshape(e.images[-1], self.image_shape)
                 elif im_name == "contour":
                     e.images.append(qstream_read_array(rcv_stream, np.uint8))
-                    e.images[-1] = np.reshape(e.images[-1],
-                                             (len(e.images[-1])//2, 2))
+                    e.images[-1] = np.reshape(
+                        e.images[-1], (len(e.images[-1])//2, 2))
                 elif im_name == "image":
                     e.images.append(qstream_read_array(rcv_stream, np.uint8))
                     e.images[-1] = np.reshape(e.images[-1], self.image_shape)

--- a/shapelink/shapelink_plugin.py
+++ b/shapelink/shapelink_plugin.py
@@ -141,10 +141,10 @@ class ShapeLinkPlugin(abc.ABC):
         send_stream.writeInt64(message_ids["MSG_ID_REGISTER_ACK"])
         if self.verbose:
             print(" Registered data container formats:")
-            print("  scalars: ", self.reg_features.scalars)
-            print("  traces:  ", self.reg_features.traces)
-            print("  images:  ", self.reg_features.images)
-            print("  image_shape:  ", self.image_shape)
+            print(" scalars:", self.reg_features.scalars)
+            print(" traces:", self.reg_features.traces)
+            print(" images:", self.reg_features.images)
+            print(" image_shape:", self.image_shape)
 
     def run_event_message(self, r, rcv_stream):
         # data package with id r

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,5 +1,6 @@
 import pathlib
 import threading
+import re
 
 from shapelink import shapein_simulator
 from shapelink import ShapeLinkPlugin
@@ -30,22 +31,43 @@ def test_run_plugin_with_simulator():
     # start plugin
     for ii in range(49):
         p.handle_messages()
+    th.join()
 
 
-def test_run_plugin_with_verbose_simulator():
+def test_run_plugin_with_verbose_simulator(capsys):
     # create new thread for simulator
     th = threading.Thread(target=shapein_simulator.start_simulator,
                           args=(str(data_dir / "calibration_beads_47.rtdc"),
                                 ["deform", "area_um"],
                                 "tcp://localhost:6666", 1)
                           )
+    # print statements from verbose simulator
+    verbose_str_1 = r"Opened dataset mm-hdf5_.* calibration_beads - M1\n"
+    verbose_str_2 = r"Send event data:\n"
+    verbose_str_3 = r"Simulation event rate: .* Hz\n" + \
+                    r"Simulation time: .* s\n"
+
+
     # setup plugin
     p = ExampleShapeLinkPlugin()
     # start simulator
     th.start()
     # start plugin
-    for ii in range(49):
+    iterations = range(51)
+    for ii in iterations:
         p.handle_messages()
+        # collect verbose print statements for checking
+        captured = capsys.readouterr()
+        if ii == 0:
+            match = re.match(verbose_str_1, captured.out)
+        elif ii == 2:
+            match = re.match(verbose_str_2, captured.out)
+        elif ii == 50:
+            match = re.match(verbose_str_3, captured.out)
+        else:
+            match = re.match('', '')
+        assert captured.out == match.group()
+    th.join()
 
 
 def test_run_plugin_with_verbose_plugin():
@@ -62,6 +84,7 @@ def test_run_plugin_with_verbose_plugin():
     # start plugin
     for ii in range(49):
         p.handle_messages()
+    th.join()
 
 
 if __name__ == "__main__":

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -30,7 +30,38 @@ def test_run_plugin_with_simulator():
     # start plugin
     for ii in range(49):
         p.handle_messages()
-    th.join()
+
+
+def test_run_plugin_with_verbose_simulator():
+    # create new thread for simulator
+    th = threading.Thread(target=shapein_simulator.start_simulator,
+                          args=(str(data_dir / "calibration_beads_47.rtdc"),
+                                ["deform", "area_um"],
+                                "tcp://localhost:6666", 1)
+                          )
+    # setup plugin
+    p = ExampleShapeLinkPlugin()
+    # start simulator
+    th.start()
+    # start plugin
+    for ii in range(49):
+        p.handle_messages()
+
+
+def test_run_plugin_with_verbose_plugin():
+    # create new thread for simulator
+    th = threading.Thread(target=shapein_simulator.start_simulator,
+                          args=(str(data_dir / "calibration_beads_47.rtdc"),
+                                ["deform", "area_um"],
+                                "tcp://localhost:6666", 0)
+                          )
+    # setup plugin
+    p = ExampleShapeLinkPlugin(verbose=True)
+    # start simulator
+    th.start()
+    # start plugin
+    for ii in range(49):
+        p.handle_messages()
 
 
 if __name__ == "__main__":

--- a/tests/test_choose_features.py
+++ b/tests/test_choose_features.py
@@ -158,7 +158,7 @@ class ChooseTraceFeaturesShapeLinkPlugin(ShapeLinkPlugin):
             *args, **kwargs)
 
     def choose_features(self):
-        user_feats = ["deform", "circ", "image", "trace"]
+        user_feats = ["deform", "circ", "trace"]
         return user_feats
 
     def handle_event(self, event_data: EventData) -> bool:
@@ -167,7 +167,6 @@ class ChooseTraceFeaturesShapeLinkPlugin(ShapeLinkPlugin):
         assert self.reg_features.traces == [
             "fl1_median", "fl1_raw", "fl2_median",
             "fl2_raw", "fl3_median", "fl3_raw"]
-        assert self.reg_features.images == ["image"]
 
         return False
 

--- a/tests/test_choose_features.py
+++ b/tests/test_choose_features.py
@@ -6,6 +6,8 @@ from shapelink import shapein_simulator
 from shapelink import ShapeLinkPlugin
 from shapelink.shapelink_plugin import EventData
 
+import numpy as np
+
 data_dir = pathlib.Path(__file__).parent / "data"
 
 
@@ -77,8 +79,44 @@ def test_run_plugin_with_bad_user_defined_features():
         p.handle_messages()
 
 
-class ChooseImageFeaturesShapeLinkPlugin(ShapeLinkPlugin):
+class ChooseScalarFeaturesShapeLinkPlugin(ShapeLinkPlugin):
     """Checks if only the chosen features are transferred"""
+    def __init__(self, *args, **kwargs):
+        super(ChooseScalarFeaturesShapeLinkPlugin, self).__init__(
+            *args, **kwargs)
+
+    def choose_features(self):
+        user_feats = ['area_cvx', 'area_msd', 'area_ratio', 'area_um',
+                      'aspect', 'bright_avg', 'bright_sd', 'circ', 'deform',
+                      'pos_x', 'pos_y', 'size_x', 'size_y',
+                      'tilt', 'time', 'volume']
+        return user_feats
+
+    def handle_event(self, event_data: EventData) -> bool:
+        """Check that the chosen scalar features were transferred"""
+        for feat in event_data.scalars:
+            assert isinstance(feat, float)
+
+        return False
+
+
+def test_run_plugin_with_user_defined_scalar_features():
+    # create new thread for simulator
+    th = threading.Thread(target=shapein_simulator.start_simulator,
+                          args=(str(data_dir / "calibration_beads_47.rtdc"),
+                                None, "tcp://localhost:6668", 0)
+                          )
+    # setup plugin
+    p = ChooseScalarFeaturesShapeLinkPlugin(bind_to='tcp://*:6668')
+    # start simulator
+    th.start()
+    # start plugin
+    for ii in range(49):
+        p.handle_messages()
+
+
+class ChooseImageFeaturesShapeLinkPlugin(ShapeLinkPlugin):
+    """Checks if only the chosen image features are transferred"""
     def __init__(self, *args, **kwargs):
         super(ChooseImageFeaturesShapeLinkPlugin, self).__init__(
             *args, **kwargs)

--- a/tests/test_choose_features.py
+++ b/tests/test_choose_features.py
@@ -158,7 +158,7 @@ class ChooseTraceFeaturesShapeLinkPlugin(ShapeLinkPlugin):
             *args, **kwargs)
 
     def choose_features(self):
-        user_feats = ["deform", "circ", "trace"]
+        user_feats = ["deform", "circ", "image", "trace"]
         return user_feats
 
     def handle_event(self, event_data: EventData) -> bool:
@@ -167,6 +167,7 @@ class ChooseTraceFeaturesShapeLinkPlugin(ShapeLinkPlugin):
         assert self.reg_features.traces == [
             "fl1_median", "fl1_raw", "fl2_median",
             "fl2_raw", "fl3_median", "fl3_raw"]
+        assert self.reg_features.images == ["image"]
 
         return False
 
@@ -175,10 +176,10 @@ def test_run_plugin_with_user_defined_trace_features():
     # create new thread for simulator
     th = threading.Thread(target=shapein_simulator.start_simulator,
                           args=(str(data_dir / "calibration_beads_47.rtdc"),
-                                None, "tcp://localhost:6667", 0)
+                                None, "tcp://localhost:6668", 0)
                           )
     # setup plugin
-    p = ChooseTraceFeaturesShapeLinkPlugin(bind_to='tcp://*:6667')
+    p = ChooseTraceFeaturesShapeLinkPlugin(bind_to='tcp://*:6668')
     # start simulator
     th.start()
     # start plugin

--- a/tests/test_choose_features.py
+++ b/tests/test_choose_features.py
@@ -6,8 +6,6 @@ from shapelink import shapein_simulator
 from shapelink import ShapeLinkPlugin
 from shapelink.shapelink_plugin import EventData
 
-import numpy as np
-
 data_dir = pathlib.Path(__file__).parent / "data"
 
 


### PR DESCRIPTION
This fixes the bug in #19. 
Not only was contour being reshaped unsuccessfully as a 2D image of shape e.g., (250, 80), but the image features were also being reshaped repeatedly if there was more than one image feature requested. Not very efficient! Fixed.

Added tests for scalar and image features chosen by the user.
Added some basic tests for the verbose options.
 